### PR TITLE
Grid arrowkey fix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
   ],
   rules: {
     'array-bracket-newline': 'warn',
+    'array-bracket-spacing': 'off',
     'no-underscore-dangle': 'off',
     'no-param-reassign': 'off',
     'import/extensions': [{ js: 'always', json: 'never' }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,9 +199,9 @@
       }
     },
     "@curriculumassociates/createjs-accessibility": {
-      "version": "1.0.0-prerelease.6",
-      "resolved": "https://registry.npmjs.org/@curriculumassociates/createjs-accessibility/-/createjs-accessibility-1.0.0-prerelease.6.tgz",
-      "integrity": "sha512-Z1cmX1FFXJx3//nWiplYHJJAYumQGGtENdgP1Vue2KbzAQOvB1wxVJzXwbBtqo/CCno6RZ+8nlzX1w6UHai0UA==",
+      "version": "1.0.0-prerelease.7",
+      "resolved": "https://registry.npmjs.org/@curriculumassociates/createjs-accessibility/-/createjs-accessibility-1.0.0-prerelease.7.tgz",
+      "integrity": "sha512-G6Dlrj8ZpyzWzpVi3Lb8hS/XBVtrXJxqdPf7jW9zNn6zHaZHHwwzx7u3U5yM+fuar8a1KrxzoDgYGj76/+wNdw==",
       "requires": {
         "keycodes-enum": "^0.0.2",
         "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack-dev-server": "3.2.1"
   },
   "dependencies": {
-    "@curriculumassociates/createjs-accessibility": "^1.0.0-prerelease.6",
+    "@curriculumassociates/createjs-accessibility": "^1.0.0-prerelease.7",
     "babel-polyfill": "^6.26.0",
     "jquery": "^3.4.1",
     "keycodes-enum": "0.0.2",

--- a/src/widgets/AppWindow.js
+++ b/src/widgets/AppWindow.js
@@ -2099,194 +2099,51 @@ export default class AppWindow extends createjs.Container {
 
   _showGridTestCase() {
     this._clearScreen();
-    const BtnData = {
-      type: 'submit',
-      value: 'SUBMIT',
-      name: 'SUBMIT',
+
+    const squareTileDimension = 30;
+    const buttonData = {
+      value: '',
       enabled: true,
-      autoFocus: 'false',
-      form: 'form_1',
-      formAction: '',
-      formMethod: 'GET',
-      formTarget: '_blank',
-      formnoValidate: '',
-      height: 30,
-      width: 90,
+      height: squareTileDimension,
+      width: squareTileDimension,
+    };
+    const buttonClickHandler = (evt) => {
+      const prevValue = evt.currentTarget.text.text;
+      let newValue;
+      if (prevValue === '') {
+        newValue = 'X';
+      } else if (prevValue === 'X') {
+        newValue = 'O';
+      } else {
+        newValue = '';
+      }
+      evt.currentTarget.text.text = newValue;
     };
 
-    const btnText = new createjs.Text('Button', '14px Arial');
-    AccessibilityModule.register({
-      displayObject: btnText,
-      role: AccessibilityModule.ROLES.NONE,
-      accessibleOptions: {
-        text: btnText.text,
-      },
-    });
-    const linkData = {
-      href: 'https://www.w3.org/TR/wai-aria-1.1/#button',
-      text: 'Button',
-    };
-    const btnLink = new Link(linkData);
-    const button = new Button(BtnData, this._nextTab++, _.noop);
+    const gridData = [];
+    for (let r = 0; r < 3; r++) {
+      const row = [];
+      for (let c = 0; c < 3; c++) {
+        const button = new Button(buttonData, -1, buttonClickHandler);
+        button.setBounds(0, 0, squareTileDimension, squareTileDimension);
+        row.push({
+          value: button,
+          type: 'cell',
+          cellWidth: squareTileDimension,
+          cellHeight: squareTileDimension,
+        });
+      }
 
-    const radioText = new createjs.Text('Radio', '14px Arial');
-    AccessibilityModule.register({
-      displayObject: radioText,
-      role: AccessibilityModule.ROLES.NONE,
-      accessibleOptions: {
-        text: radioText.text,
-      },
-    });
-    const radioLinkData = {
-      href: 'https://www.w3.org/TR/wai-aria-1.1/#radio',
-      text: 'Radio',
-    };
-    const radioLink = new Link(radioLinkData);
-    const radio = new Radio({
-      name: 'Radio',
-      value: 'Radio',
-      position: 1,
-      size: 1,
-      tabIndex: this.tabIndex ? this.tabIndex++ : undefined,
-    });
+      gridData.push(row);
+    }
 
-    const checkBoxText = new createjs.Text('CheckBox', '14px Arial');
-    AccessibilityModule.register({
-      displayObject: checkBoxText,
-      role: AccessibilityModule.ROLES.NONE,
-      accessibleOptions: {
-        text: checkBoxText.text,
-      },
-    });
-    const checkBoxLinkData = {
-      href: 'https://www.w3.org/TR/wai-aria-1.1/#checkbox',
-      text: 'CheckBox',
-    };
-    const checkBoxLink = new Link(checkBoxLinkData);
-    const checkBox = new CheckBox(25, 25, this._nextTab++);
+    const grid = new Grid(gridData, this._nextTab++);
+    this._contentArea.addChild(grid);
+    this._contentArea.accessible.addChild(grid);
 
-    const labelText = new createjs.Text('Widget ', '14px Arial');
-    AccessibilityModule.register({
-      displayObject: labelText,
-      role: AccessibilityModule.ROLES.NONE,
-      accessibleOptions: {
-        text: labelText.text,
-      },
-    });
-    const linkText = new createjs.Text('Link ', '14px Arial');
-    AccessibilityModule.register({
-      displayObject: linkText,
-      role: AccessibilityModule.ROLES.NONE,
-      accessibleOptions: {
-        text: linkText.text,
-      },
-    });
-    const interactionText = new createjs.Text('Interaction ', '14px Arial');
-    AccessibilityModule.register({
-      displayObject: interactionText,
-      role: AccessibilityModule.ROLES.NONE,
-      accessibleOptions: {
-        text: interactionText.text,
-      },
-    });
-
-    const row1 = [
-      {
-        value: linkText,
-        type: 'header',
-        cellWidth: 265,
-        cellHeight: 70,
-      },
-      {
-        value: interactionText,
-        type: 'header',
-        cellWidth: 265,
-        cellHeight: 70,
-      },
-      {
-        value: labelText,
-        type: 'header',
-        cellWidth: 265,
-        cellHeight: 70,
-      },
-    ];
-
-    const row2 = [
-      {
-        value: btnText,
-        type: 'cell',
-        cellWidth: 265,
-        cellHeight: 70,
-      },
-      {
-        value: btnLink,
-        type: 'cell',
-        cellWidth: 265,
-        cellHeight: 70,
-      },
-      {
-        value: button,
-        type: 'cell',
-        cellWidth: 265,
-        cellHeight: 70,
-      },
-    ];
-
-    const row3 = [
-      {
-        value: checkBoxText,
-        type: 'cell',
-        cellWidth: 265,
-        cellHeight: 70,
-      },
-      {
-        value: checkBoxLink,
-        type: 'cell',
-        cellWidth: 265,
-        cellHeight: 70,
-      },
-      {
-        value: checkBox,
-        type: 'cell',
-        cellWidth: 265,
-        cellHeight: 70,
-      },
-    ];
-
-    const row4 = [
-      {
-        value: radioText,
-        type: 'cell',
-        cellWidth: 265,
-        cellHeight: 70,
-      },
-      {
-        value: radioLink,
-        type: 'cell',
-        cellWidth: 265,
-        cellHeight: 70,
-      },
-      {
-        value: radio,
-        type: 'cell',
-        cellWidth: 265,
-        cellHeight: 70,
-      },
-    ];
-    const data = [row1, row2, row3, row4];
-    const tableBody = new Grid(data, this._nextTab++);
-    const table = new createjs.Container();
-    table.addChild(tableBody);
-    AccessibilityModule.register({
-      displayObject: table,
-      role: AccessibilityModule.ROLES.GRID,
-    });
-    table.accessible.addChild(tableBody);
-    table.accessible.rowcount = tableBody.rowCount;
-    table.accessible.colcount = tableBody.colCount;
-    this._contentArea.addChild(table);
-    this._contentArea.accessible.addChild(table);
-    table.y = 20;
+    // just moving the grid so it's not right up against the menu bar or left side of the window
+    grid.x = 50;
+    grid.y = 50;
   }
 
 

--- a/src/widgets/AppWindow.js
+++ b/src/widgets/AppWindow.js
@@ -19,7 +19,6 @@ import SingleLineTextInput from './SingleLineTextInput';
 import MultiLineTextInput from './MultiLineTextInput';
 import CheckBox from './CheckBox';
 import Search from './Search';
-import Radio from './Radio';
 import RadioGroup from './RadioGroup';
 import Draggable from './Draggable';
 import Slider from './Slider';

--- a/src/widgets/AppWindow.js
+++ b/src/widgets/AppWindow.js
@@ -2387,7 +2387,7 @@ export default class AppWindow extends createjs.Container {
       cellHeight: 60,
     };
 
-    const treeGrid = new TreeGrid(data, this._nextTab++);
+    const treeGrid = new TreeGrid(data, 0);
     this._contentArea.addChild(treeGrid);
     this._contentArea.accessible.addChild(treeGrid);
     treeGrid.y = 20;

--- a/src/widgets/AppWindow.js
+++ b/src/widgets/AppWindow.js
@@ -2348,7 +2348,7 @@ export default class AppWindow extends createjs.Container {
     };
 
     const row1 = {
-      rowData: ['III', 'Anish', '420'],
+      rowData: ['III', 'Anish', '5'],
       childrenData: 1,
       type: 'cell',
       level: 1,
@@ -2375,32 +2375,23 @@ export default class AppWindow extends createjs.Container {
     };
 
     const row5 = {
-      rowData: ['XI', 'Sudhir', '20'],
+      rowData: ['XI', 'Sudhir', '30'],
       level: 1,
       type: 'cell',
       childrenData: 0,
     };
 
-    const rows = [row0, row1, row2, row3, row4, row5];
+    const rows = [ row0, row1, row2, row3, row4, row5 ];
     const data = {
       rows,
       cellWidth: 265,
       cellHeight: 60,
     };
 
-    const tableBody = new TreeGrid(data, this._nextTab++);
-    const table = new createjs.Container();
-    table.addChild(tableBody);
-    AccessibilityModule.register({
-      displayObject: table,
-      role: AccessibilityModule.ROLES.TREEGRID,
-    });
-    table.accessible.addChild(tableBody);
-    table.accessible.rowcount = tableBody.rowCount;
-    table.accessible.colcount = tableBody.colCount;
-    this._contentArea.addChild(table);
-    this._contentArea.accessible.addChild(table);
-    table.y = 20;
+    const treeGrid = new TreeGrid(data, this._nextTab++);
+    this._contentArea.addChild(treeGrid);
+    this._contentArea.accessible.addChild(treeGrid);
+    treeGrid.y = 20;
   }
 
   _showTreeTestCase() {

--- a/src/widgets/Button.js
+++ b/src/widgets/Button.js
@@ -4,13 +4,14 @@ import AccessibilityModule from '@curriculumassociates/createjs-accessibility';
 export default class Button extends createjs.Container {
   constructor(options, tabIndex, callBack = _.noop) {
     super();
-    _.bindAll(this, '_onFocus', '_onBlur', '_onMouseDown', '_onMouseUp');
+    _.bindAll(this, '_onFocus', '_onBlur', '_onMouseDown', '_onMouseUp', '_onClick');
     this.callBack = callBack;
     this.addEventListener('focus', this._onFocus);
     this.addEventListener('blur', this._onBlur);
     this.addEventListener('mousedown', this._onMouseDown);
     this.addEventListener('mouseup', this._onMouseUp);
-    this.addEventListener('keyboardClick', this._onMouseDown);
+    this.addEventListener('click', this._onClick);
+    this.addEventListener('keyboardClick', this._onClick);
 
     options.tabIndex = tabIndex;
     AccessibilityModule.register({
@@ -90,7 +91,6 @@ export default class Button extends createjs.Container {
   }
 
   _onFocus() {
-    this.accessible.requestFocus();
     this.focusRect.visible = true;
   }
 
@@ -98,12 +98,16 @@ export default class Button extends createjs.Container {
     this.focusRect.visible = false;
   }
 
-  _onMouseDown(evt) {
-    this.accessible.requestFocus();
-    this.callBack(evt);
+  _onMouseDown() {
+    this.background.visible = false;
   }
 
   _onMouseUp() {
     this.background.visible = true;
+  }
+
+  _onClick(evt) {
+    this.accessible.requestFocus();
+    this.callBack(evt);
   }
 }

--- a/src/widgets/Button.js
+++ b/src/widgets/Button.js
@@ -98,9 +98,9 @@ export default class Button extends createjs.Container {
     this.focusRect.visible = false;
   }
 
-  _onMouseDown() {
+  _onMouseDown(evt) {
     this.accessible.requestFocus();
-    this.callBack();
+    this.callBack(evt);
   }
 
   _onMouseUp() {

--- a/src/widgets/Grid.js
+++ b/src/widgets/Grid.js
@@ -18,7 +18,7 @@ export default class Grid extends createjs.Container {
 
     this.tabIndex = tabIndex;
     this.data = data;
-    this.rowCount = this.data.length + 1; // +1 due to header row
+    this.rowCount = this.data.length;
     this.colCount = this.data[0].length;
     this.cellWidths = _.map(this.data[0], 'cellWidth');
     this.cellHeight = this.data[0][0].cellHeight;

--- a/src/widgets/Grid.js
+++ b/src/widgets/Grid.js
@@ -29,7 +29,7 @@ export default class Grid extends createjs.Container {
 
     const firstCellWidget = _.get(data, '[0][0]');
     if (!firstCellWidget || !firstCellWidget.value) {
-      throw new Error('Invalid data sent to grid widget: the first row does not have a cell');
+      throw new Error('Invalid data sent to grid widget: the first row\'s first cell does not have a widget');
     }
     firstCellWidget.value.accessible.tabIndex = tabIndex;
   }

--- a/src/widgets/Grid.js
+++ b/src/widgets/Grid.js
@@ -6,8 +6,16 @@ export default class Grid extends createjs.Container {
     super();
     AccessibilityModule.register({
       displayObject: this,
+      role: AccessibilityModule.ROLES.GRID,
+    });
+    this.table = new createjs.Container();
+    AccessibilityModule.register({
+      displayObject: this.table,
       role: AccessibilityModule.ROLES.TABLEBODY,
     });
+    this.addChild(this.table);
+    this.accessible.addChild(this.table);
+
     this.tabIndex = tabIndex;
     this.data = data;
     this.rowCount = this.data.length + 1; // +1 due to header row
@@ -28,10 +36,10 @@ export default class Grid extends createjs.Container {
   createRows() {
     for (let i = 0; i < this.rowCount; i++) {
       const row = this._createContainer(this.totalWidth, this.cellHeight);
-      this.addChild(row);
+      this.table.addChild(row);
       AccessibilityModule.register({
         displayObject: row,
-        parent: this,
+        parent: this.table,
         role: AccessibilityModule.ROLES.ROW,
       });
       _.forEach(this.data[i], (data, index) => {
@@ -55,7 +63,6 @@ export default class Grid extends createjs.Container {
             role: AccessibilityModule.ROLES.GRIDCELL,
           });
         }
-        cell.accessible.tabIndex = this.tabIndex++;
         cell.accessible.addChild(cell.cellContent);
       });
 
@@ -103,11 +110,10 @@ export default class Grid extends createjs.Container {
         left = (this.cellWidths[index] - cellContentBounds.width) / 2;
         break;
     }
-    cellContent.set({
-      x: left,
-      y: ((this.cellHeight - cellContentBounds.height) >= 0)
-        ? ((this.cellHeight - cellContentBounds.height) / 2) : 0,
-    });
+    cellContent.x = left;
+    cellContent.y = ((this.cellHeight - cellContentBounds.height) >= 0)
+      ? ((this.cellHeight - cellContentBounds.height) / 2)
+      : 0;
 
     cell.cellContent = cellContent;
     const shape = new createjs.Shape();

--- a/src/widgets/Grid.js
+++ b/src/widgets/Grid.js
@@ -26,6 +26,12 @@ export default class Grid extends createjs.Container {
     this.rows = [];
     this.setBounds(0, 0, this.totalWidth, this.cellHeight * this.rowcount);
     this.createTable();
+
+    const firstCellWidget = _.get(data, '[0][0]');
+    if (!firstCellWidget || !firstCellWidget.value) {
+      throw new Error('Invalid data sent to grid widget: the first row does not have a cell');
+    }
+    firstCellWidget.value.accessible.tabIndex = tabIndex;
   }
 
   createTable() {
@@ -72,22 +78,10 @@ export default class Grid extends createjs.Container {
 
   setupLayout() {
     _.forEach(this.rows, (row, i) => {
-      row.set({
-        y: this.cellHeight * i,
-      });
-      row.rowIndex = i;
-      row.accessible.rowindex = i;
+      row.y = this.cellHeight * i;
 
       _.forEach(row.children, (cell, j) => {
-        cell.set({
-          x: _.sum(_.slice(this.cellWidths, 0, j)),
-        });
-        cell.rowIndex = i;
-        cell.colIndex = j;
-        cell.accessible.rowindex = i;
-        cell.accessible.colindex = j;
-        cell.accessible.rowspan = 1;
-        cell.accessible.colspan = 1;
+        cell.x = _.sum(_.slice(this.cellWidths, 0, j));
       });
     });
   }

--- a/src/widgets/TreeGrid.js
+++ b/src/widgets/TreeGrid.js
@@ -43,7 +43,8 @@ export default class TreeGrid extends createjs.Container {
 
     this._createTable();
 
-    const firstFocusableRow = _.find(this._table.accessible.children, row => !_.isUndefined(row.accessible.tabIndex));
+    const firstFocusableRow = _.find(this._table.accessible.children,
+      row => !_.isUndefined(row.accessible.tabIndex));
     firstFocusableRow.accessible.tabIndex = tabIndex;
 
     window.foo = this;

--- a/src/widgets/TreeGrid.js
+++ b/src/widgets/TreeGrid.js
@@ -6,7 +6,7 @@ const OFFSET = 20;
 
 export default class TreeGrid extends createjs.Container {
   constructor(data, tabIndex) {
-    super(data, tabIndex);
+    super();
     _.bindAll(this, '_onCollapseRow', '_onExpandRow');
 
     AccessibilityModule.register({

--- a/src/widgets/TreeGrid.js
+++ b/src/widgets/TreeGrid.js
@@ -31,7 +31,6 @@ export default class TreeGrid extends createjs.Container {
     });
     this.addChild(this._table);
     this.accessible.addChild(this._table);
-    this._tabIndex = tabIndex;
     this._data = data.rows;
     this._numRows = data.rows.length;
     this._numCols = data.rows[0].rowData.length;
@@ -43,6 +42,9 @@ export default class TreeGrid extends createjs.Container {
     this.setBounds(0, 0, this._totalWidth, this._totalHeight);
 
     this._createTable();
+
+    const firstFocusableRow = _.find(this._table.accessible.children, row => !_.isUndefined(row.accessible.tabIndex));
+    firstFocusableRow.accessible.tabIndex = tabIndex;
 
     window.foo = this;
   }
@@ -57,7 +59,7 @@ export default class TreeGrid extends createjs.Container {
     const rowHeight = this._cellHeight;
     const cellCount = this._numCols;
     for (let i = 0; i < this._data.length; i++) {
-      const row = new TreeGridRow(this._data[i], i, rowWidth, rowHeight, cellCount, this._tabIndex++); // eslint-disable-line max-len
+      const row = new TreeGridRow(this._data[i], i, rowWidth, rowHeight, cellCount); // eslint-disable-line max-len
       row.collapsedArrow.addEventListener('click', this._onExpandRow);
       row.expandedArrow.addEventListener('click', this._onCollapseRow);
       this._table.addChild(row);

--- a/src/widgets/TreeGrid.js
+++ b/src/widgets/TreeGrid.js
@@ -57,7 +57,7 @@ export default class TreeGrid extends createjs.Container {
     const rowHeight = this._cellHeight;
     const cellCount = this._numCols;
     for (let i = 0; i < this._data.length; i++) {
-      const row = new TreeGridRow(this._data[i], i, rowWidth, rowHeight, cellCount, this._tabIndex++);
+      const row = new TreeGridRow(this._data[i], i, rowWidth, rowHeight, cellCount, this._tabIndex++); // eslint-disable-line max-len
       row.collapsedArrow.addEventListener('click', this._onExpandRow);
       row.expandedArrow.addEventListener('click', this._onCollapseRow);
       this._table.addChild(row);
@@ -74,7 +74,9 @@ export default class TreeGrid extends createjs.Container {
     row.expanded = true;
     const showRowsAtLevel = row.accessible.level + 1;
     const startUpdateIndex = _.findIndex(this._rows, row) + 1;
-    let finalUpdateIndex = _.findIndex(this._rows, testRow => testRow.accessible.level <= row.accessible.level, startUpdateIndex) - 1;
+    let finalUpdateIndex = _.findIndex(this._rows,
+      testRow => testRow.accessible.level <= row.accessible.level,
+      startUpdateIndex) - 1;
     if (finalUpdateIndex < 0) {
       finalUpdateIndex = this._rows.length - 1;
     }
@@ -84,7 +86,8 @@ export default class TreeGrid extends createjs.Container {
       if (showRowsAtLevel === rowLevel) {
         checkRow.visible = true;
         if (checkRow.accessible.expanded) {
-          // need to recurse to update the visibility of rows that are expanded decendants of this one
+          // need to recurse to update the visibility of rows that are expanded
+          // decendants of this one
           this._onExpandRow({ rowDisplayObject: checkRow });
         }
       }
@@ -99,7 +102,9 @@ export default class TreeGrid extends createjs.Container {
 
     row.expanded = false;
     const startUpdateIndex = _.findIndex(this._rows, row) + 1;
-    let finalUpdateIndex = _.findIndex(this._rows, testRow => testRow.accessible.level <= row.accessible.level, startUpdateIndex) - 1;
+    let finalUpdateIndex = _.findIndex(this._rows,
+      testRow => testRow.accessible.level <= row.accessible.level,
+      startUpdateIndex) - 1;
     if (finalUpdateIndex < 0) {
       finalUpdateIndex = this._rows.length - 1;
     }

--- a/src/widgets/TreeGrid.js
+++ b/src/widgets/TreeGrid.js
@@ -110,47 +110,6 @@ export default class TreeGrid extends createjs.Container {
     this._setupLayout();
   }
 
-  _toggleTreeVisibility(evt) {
-    // todo
-    // const { currentTarget } =  evt;
-    // currentTarget.opened = !currentTarget.opened;
-    // currentTarget.hasChildren && currentTarget.toggleArrow();
-    // if (currentTarget.opened) {
-    //   this.open(currentTarget);
-    // } else {
-    //   this.close(currentTarget);
-    // }
-    // this.setupLayout();
-  }
-
-  // open(currentTarget) {
-  //   if (currentTarget.hasChildren) {
-  //     const lastChild = this.updateVisibility(currentTarget, true);
-  //     if (lastChild.opened && lastChild.hasChildren > 0) {
-  //       this.open(lastChild);
-  //     }
-  //   }
-  // }
-  //
-  // close(currentTarget) {
-  //   if (currentTarget.data.childrenData > 0) {
-  //     const lastChild = this.updateVisibility(currentTarget, false);
-  //     if (!lastChild.visible && lastChild.data.childrenData > 0) {
-  //       this.close(lastChild);
-  //     }
-  //   }
-  // }
-
-  // updateVisibility(currentTarget, visible) {
-  //   let lastChild;
-  //   const noOfchildren = currentTarget.index + currentTarget.data.childrenData;
-  //   for (let i = currentTarget.index + 1; i < noOfchildren + 1; i++) {
-  //     this.rows[i].visible = visible;
-  //     lastChild = this.rows[i];
-  //   }
-  //   return lastChild;
-  // }
-
   _setupLayout() {
     let previousRow = this._rows[0];
     for (let i = 1; i < this._rows.length; i++) {

--- a/src/widgets/TreeGrid.js
+++ b/src/widgets/TreeGrid.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import AccessibilityModule from '@curriculumassociates/createjs-accessibility';
 import TreeGridRow from './TreeGridRow';
 
@@ -6,113 +7,158 @@ const OFFSET = 20;
 export default class TreeGrid extends createjs.Container {
   constructor(data, tabIndex) {
     super(data, tabIndex);
+    _.bindAll(this, '_onCollapseRow', '_onExpandRow');
+
     AccessibilityModule.register({
       displayObject: this,
+      role: AccessibilityModule.ROLES.TREEGRID,
+      events: [
+        {
+          eventName: 'collapseRow',
+          listener: this._onCollapseRow,
+        },
+        {
+          eventName: 'expandRow',
+          listener: this._onExpandRow,
+        },
+      ],
+    });
+
+    this._table = new createjs.Container();
+    AccessibilityModule.register({
+      displayObject: this._table,
       role: AccessibilityModule.ROLES.TABLEBODY,
     });
-    this.tabIndex = tabIndex;
-    this.data = data.rows;
-    this.rowCount = this.data.length;
-    this.colCount = this.data[0].rowData.length;
-    this.cellWidth = data.cellWidth;
-    this.cellHeight = data.cellHeight;
-    this.totalWidth = data.cellWidth * this.colCount;
-    this.totalHeight = data.cellHeight * this.rowCount;
-    this.rows = [];
-    this.setBounds(0, 0, this.totalWidth, this.totalHeight);
+    this.addChild(this._table);
+    this.accessible.addChild(this._table);
+    this._tabIndex = tabIndex;
+    this._data = data.rows;
+    this._numRows = data.rows.length;
+    this._numCols = data.rows[0].rowData.length;
+    this._cellWidth = data.cellWidth;
+    this._cellHeight = data.cellHeight;
+    this._totalWidth = data.cellWidth * this._numCols;
+    this._totalHeight = data.cellHeight * this._numRows;
+    this._rows = [];
+    this.setBounds(0, 0, this._totalWidth, this._totalHeight);
 
-    this.createTable();
+    this._createTable();
+
+    window.foo = this;
   }
 
-  createTable() {
-    this.createRows();
-    this.setupLayout();
+  _createTable() {
+    this._createRows();
+    this._setupLayout();
   }
 
-  createRows() {
-    const rowWidth = this.totalWidth;
-    const rowHeight = this.cellHeight;
-    const cellCount = this.colCount;
-    const { data } = this;
-    for (let i = 0; i < data.length; i++) {
-      const index = i;
-      const row = new TreeGridRow(data[i], index, rowWidth, rowHeight, cellCount, this.tabIndex++);
-      row.addEventListener('keyboardClick', this.toggleTreeVisibility.bind(this));
-      row.addEventListener('click', this.toggleTreeVisibility.bind(this));
-      row.addRowData();
-      this.addChild(row);
-      this.accessible.addChild(row);
-      this.rows.push(row);
-      if (data[i].level === 1) {
-        row.visible = true;
-      } else {
-        row.visible = false;
-      }
-      row.hasChildren = (row.data.childrenData > 0);
-      row.opened = false;
+  _createRows() {
+    const rowWidth = this._totalWidth;
+    const rowHeight = this._cellHeight;
+    const cellCount = this._numCols;
+    for (let i = 0; i < this._data.length; i++) {
+      const row = new TreeGridRow(this._data[i], i, rowWidth, rowHeight, cellCount, this._tabIndex++);
+      row.collapsedArrow.addEventListener('click', this._onExpandRow);
+      row.expandedArrow.addEventListener('click', this._onCollapseRow);
+      this._table.addChild(row);
+      this._table.accessible.addChild(row);
+      this._rows.push(row);
+      row.visible = this._data[i].level === 1;
     }
   }
 
-  toggleTreeVisibility(evt) {
-    const { currentTarget } = evt;
-    currentTarget.opened = !currentTarget.opened;
-    currentTarget.hasChildren && currentTarget.toggleArrow();
-    if (currentTarget.opened) {
-      this.open(currentTarget);
-    } else {
-      this.close(currentTarget);
-    }
-    this.setupLayout();
-  }
+  _onExpandRow(evt) {
+    // to handle both CAM expandRow event and CJS click event with the same listener
+    const row = evt.rowDisplayObject || evt.target.parent;
 
-  open(currentTarget) {
-    if (currentTarget.hasChildren) {
-      const lastChild = this.updateVisibility(currentTarget, true);
-      if (lastChild.opened && lastChild.hasChildren > 0) {
-        this.open(lastChild);
+    row.expanded = true;
+    const showRowsAtLevel = row.accessible.level + 1;
+    const startUpdateIndex = _.findIndex(this._rows, row) + 1;
+    let finalUpdateIndex = _.findIndex(this._rows, testRow => testRow.accessible.level <= row.accessible.level, startUpdateIndex) - 1;
+    if (finalUpdateIndex < 0) {
+      finalUpdateIndex = this._rows.length - 1;
+    }
+    for (let i = startUpdateIndex; i <= finalUpdateIndex; i++) {
+      const checkRow = this._rows[i];
+      const rowLevel = checkRow.accessible.level;
+      if (showRowsAtLevel === rowLevel) {
+        checkRow.visible = true;
+        if (checkRow.accessible.expanded) {
+          // need to recurse to update the visibility of rows that are expanded decendants of this one
+          this._onExpandRow({ rowDisplayObject: checkRow });
+        }
       }
     }
+
+    this._setupLayout();
   }
 
-  close(currentTarget) {
-    if (currentTarget.data.childrenData > 0) {
-      const lastChild = this.updateVisibility(currentTarget, false);
-      if (!lastChild.visible && lastChild.data.childrenData > 0) {
-        this.close(lastChild);
+  _onCollapseRow(evt) {
+    // to handle both CAM collapseRow event and CJS click events with the same listener
+    const row = evt.rowDisplayObject || evt.currentTarget.parent;
+
+    row.expanded = false;
+    const startUpdateIndex = _.findIndex(this._rows, row) + 1;
+    let finalUpdateIndex = _.findIndex(this._rows, testRow => testRow.accessible.level <= row.accessible.level, startUpdateIndex) - 1;
+    if (finalUpdateIndex < 0) {
+      finalUpdateIndex = this._rows.length - 1;
+    }
+    for (let i = startUpdateIndex; i <= finalUpdateIndex; i++) {
+      this._rows[i].visible = false;
+    }
+
+    this._setupLayout();
+  }
+
+  _toggleTreeVisibility(evt) {
+    // todo
+    // const { currentTarget } =  evt;
+    // currentTarget.opened = !currentTarget.opened;
+    // currentTarget.hasChildren && currentTarget.toggleArrow();
+    // if (currentTarget.opened) {
+    //   this.open(currentTarget);
+    // } else {
+    //   this.close(currentTarget);
+    // }
+    // this.setupLayout();
+  }
+
+  // open(currentTarget) {
+  //   if (currentTarget.hasChildren) {
+  //     const lastChild = this.updateVisibility(currentTarget, true);
+  //     if (lastChild.opened && lastChild.hasChildren > 0) {
+  //       this.open(lastChild);
+  //     }
+  //   }
+  // }
+  //
+  // close(currentTarget) {
+  //   if (currentTarget.data.childrenData > 0) {
+  //     const lastChild = this.updateVisibility(currentTarget, false);
+  //     if (!lastChild.visible && lastChild.data.childrenData > 0) {
+  //       this.close(lastChild);
+  //     }
+  //   }
+  // }
+
+  // updateVisibility(currentTarget, visible) {
+  //   let lastChild;
+  //   const noOfchildren = currentTarget.index + currentTarget.data.childrenData;
+  //   for (let i = currentTarget.index + 1; i < noOfchildren + 1; i++) {
+  //     this.rows[i].visible = visible;
+  //     lastChild = this.rows[i];
+  //   }
+  //   return lastChild;
+  // }
+
+  _setupLayout() {
+    let previousRow = this._rows[0];
+    for (let i = 1; i < this._rows.length; i++) {
+      if (this._rows[i].visible) {
+        this._rows[i].x = (this._rows[i].data.level - 1) * OFFSET;
+        this._rows[i].y = previousRow.y + this._cellHeight;
+        previousRow = this._rows[i];
       }
     }
-  }
-
-  updateVisibility(currentTarget, visible) {
-    let lastChild;
-    const noOfchildren = currentTarget.index + currentTarget.data.childrenData;
-    for (let i = currentTarget.index + 1; i < noOfchildren + 1; i++) {
-      this.rows[i].visible = visible;
-      lastChild = this.rows[i];
-    }
-    return lastChild;
-  }
-
-  setupLayout() {
-    let previousRow = this.rows[0];
-    for (let i = 1; i < this.rows.length; i++) {
-      if (this.rows[i].visible) {
-        this.rows[i].set({
-          y: previousRow.y + this.cellHeight,
-          x: (this.rows[i].data.level - 1) * OFFSET,
-        });
-        previousRow = this.rows[i];
-      }
-    }
-  }
-
-  onFocus(evt) {
-    this.focusRect.visible = true;
-    evt.preventDefault();
-    evt.stopPropagation();
-  }
-
-  onBlur() {
-    this.focusRect.visible = false;
   }
 }

--- a/src/widgets/TreeGridRow.js
+++ b/src/widgets/TreeGridRow.js
@@ -34,7 +34,7 @@ export default class TreeGridRow extends createjs.Container {
     this.cellHeight = rowHeight;
 
     const bg = new createjs.Shape();
-    bg.graphics.beginStroke('black').beginFill('#cccbbb').dr(0, 0, rowWidth, rowHeight);
+    bg.graphics.beginStroke('black').beginFill('#cccbbb').drawRect(0, 0, rowWidth, rowHeight);
     bg.setBounds(0, 0, rowWidth, rowHeight);
     this.addChild(bg);
 

--- a/src/widgets/TreeGridRow.js
+++ b/src/widgets/TreeGridRow.js
@@ -196,7 +196,6 @@ export default class TreeGridRow extends createjs.Container {
     _.forEach(focusablesInRow, (focusable) => {
       focusable.accessible.tabIndex = 0;
     });
-    // todo: setup so that when the last focusable element in the row gets a blur, focusable elements in the row's focusable elements get removed from the tab order
   }
 
   _onBlur() {

--- a/src/widgets/TreeGridRow.js
+++ b/src/widgets/TreeGridRow.js
@@ -167,7 +167,12 @@ export default class TreeGridRow extends createjs.Container {
     return container;
   }
 
-  _createText({ value, maxWidth, bold = false, fontSize = 18, }) {
+  _createText({
+    value,
+    maxWidth,
+    bold = false,
+    fontSize = 18,
+  }) {
     const boldOption = bold ? 'bold' : '';
     const text = new createjs.Text().set({
       text: value,


### PR DESCRIPTION
Updating the grid and treegrid roles (since treegrid depends on grid code-wise) to follow WAI-ARIA practices for the various keystrokes that determine how focus moves through a grid or treegrid